### PR TITLE
Fix/recover hexa code

### DIFF
--- a/src/components/next-iro/colorPicker.tsx
+++ b/src/components/next-iro/colorPicker.tsx
@@ -29,7 +29,12 @@ const ColorPicker: React.FC = () => {
         };
     }, [state, state?.handleColorSelection]);
 
-    return <div ref={colorPickerRef}></div>;
+    return( 
+        <>
+            <div ref={colorPickerRef}></div>
+            <div>Selected Color: {state?.selectedColor}</div>
+        </>
+);
 };
 
 export default ColorPicker;


### PR DESCRIPTION
Updated the Color Picker tool with the hexadecimal code. After we implemented the context, the hexadecimal code was not showing anymore.